### PR TITLE
1.0.1

### DIFF
--- a/CGPfunctions.Rproj
+++ b/CGPfunctions.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 5
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/R/Plot2WayANOVA.R
+++ b/R/Plot2WayANOVA.R
@@ -171,13 +171,13 @@ Plot2WayANOVA <- function(formula, dataframe = NULL, confidence=.95, plottype = 
          bar =
            newdata %>% ggplot(aes_string(x = iv1, y= "TheMean", colour= iv2, fill= iv2, group=iv2)) +
             geom_bar(stat = "identity", position = "dodge") +
-            geom_errorbar(aes(ymin=LowerBound, ymax=UpperBound), width=.5, position = "dodge", show.legend = FALSE) +
+            geom_errorbar(aes(ymin=LowerBound, ymax=UpperBound), width=.5, position = position_dodge(0.9), show.legend = FALSE) +
             commonstuff -> p,
          line =
            newdata %>% ggplot(aes_string(x = iv1, y= "TheMean", colour= iv2, fill= iv2, group=iv2)) +
-            geom_errorbar(aes(ymin=LowerBound, ymax=UpperBound), width=.2) +
-            geom_line() +
-            geom_point(aes(y=TheMean)) +
+            geom_errorbar(aes(ymin=LowerBound, ymax=UpperBound), position=position_dodge(0.9),width=.2) +
+            geom_line(position=position_dodge(0.9)) +
+            geom_point(aes(y=TheMean),position=position_dodge(0.9)) +
             commonstuff -> p
   )
   


### PR DESCRIPTION
Some modification of Plot2WayANOVA function

1) to match the position of bar and errorbar
![rplot](https://user-images.githubusercontent.com/7410607/41951959-8d33c01c-7a08-11e8-8e5f-e3fca5bc13cd.png)


1) to avoid the overlapping of errorbar
![rplot01](https://user-images.githubusercontent.com/7410607/41951972-9c208060-7a08-11e8-9196-3926ec47670f.png)
